### PR TITLE
fix: enable dependabot security and vulnerability

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,4 @@ updates:
     open-pull-requests-limit: 5
     allow:
       - dependency-type: "all"
-    # Enable security updates
-    security-updates-only: true
+    


### PR DESCRIPTION
## Type of Change
Fix
## Description
This PR fixes an issue with dependabot by removing the unsupported security-updates-only property
## Related Issues
Addresses #69  
## Screenshots
--
## Other Notes
--
